### PR TITLE
[docs] document npm install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ _**N.B.** If currently use Nuxt's `config.env` option, fear not—`nuxt-env` inc
 ### Get Setup
 
 1. Install the dependency:
+
+```bash
+npm install nuxt-env
+```
+
+or if you use Yarn
+
 ```bash
 yarn add nuxt-env
 ```


### PR DESCRIPTION
A simple documentation update to show how to install with both yarn and npm.

Only showing `yarn add nuxt-env` in the README had one of our junior developers thinking that the module _needed_ to be installed with Yarn, while the rest of our code base uses npm.
